### PR TITLE
removed unused method instances from export names

### DIFF
--- a/src/AbstractLattices.jl
+++ b/src/AbstractLattices.jl
@@ -2,9 +2,9 @@ module AbstractLattices
 
 export ∧, ∨, dist
 
-function (∧)(x,y) end
-function (∨)(x,y) end
+function ∧ end
+function ∨ end
 
-function dist() end
+function dist end
 
 end


### PR DESCRIPTION
while developing the [Grassmann.jl](https://github.com/chakravala/Grassmann.jl), I encountered some issues involving the method definitions due to the `AbstractLattices` package. It would be preferred if the package would export the names without any method instances, so as not to confuse the dispatch.

The methods did not do anything anyway, so I think it's better to not have them, since they mysteriously caused my expressions to result in `nothing` values sometimes, which is incorrect.