### PR TITLE
introduced wedge and vee aliases for methods

### DIFF
--- a/src/AbstractLattices.jl
+++ b/src/AbstractLattices.jl
@@ -1,9 +1,12 @@
 module AbstractLattices
 
-export ∧, ∨, dist
+export ∧, ∨, dist, wedge, vee
 
-function ∧ end
-function ∨ end
+function wedge end
+function vee end
+
+const ∧ = wedge
+const ∨ = vee
 
 function dist end
 


### PR DESCRIPTION
this change shouldn't affect the compatibility of your code

it is similar to the `LinearAlgebra.dot` method, which is the alias of `⋅` (the `\cdot` methods)