### PR TITLE
add empty wedge unit value

### DIFF
--- a/src/AbstractLattices.jl
+++ b/src/AbstractLattices.jl
@@ -10,4 +10,6 @@ const ∨ = vee
 
 function dist end
 
+wedge() = 1
+
 end


### PR DESCRIPTION
Recently, I came to the realization that the determinant of a 0x0 matrix is 1.
```Julia
julia> LinearAlgebra.det(Matrix{Float64}(undef,0,0))
1.0
```
In my [Grassmann.jl](https://github.com/chakravala/Grassmann.jl) package, I am using `wedge` for the exterior product, and so it makes sense to have `wedge() = 1` defined, since that would be the equivalent of the determinant of a 0x0 matrix.

If this conflicts with your definitions, it's not necessary to merge this pull request, let me know if it's compatible for you.